### PR TITLE
Add skeleton and wireframe display features

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,26 @@
           <input type="checkbox" id="wireframe-checkbox" class="modern-checkbox">
           <label for="wireframe-checkbox">Wireframe</label>
         </div>
+
+        <div class="checkbox-control">
+          <input type="checkbox" id="bounding-box-checkbox" class="modern-checkbox">
+          <label for="bounding-box-checkbox">Bounding Box</label>
+        </div>
+
+        <div class="checkbox-control">
+          <input type="checkbox" id="show-axes-checkbox" class="modern-checkbox">
+          <label for="show-axes-checkbox">Show Axes</label>
+        </div>
+
+        <div class="checkbox-control">
+          <input type="checkbox" id="show-normals-checkbox" class="modern-checkbox">
+          <label for="show-normals-checkbox">Show Normals</label>
+        </div>
+
+        <div class="checkbox-control">
+          <input type="checkbox" id="show-edges-checkbox" class="modern-checkbox">
+          <label for="show-edges-checkbox">Show Edges</label>
+        </div>
       </div>
 
       <!-- Frame lock controls -->


### PR DESCRIPTION
Added four new visualization options to the View section:
- Bounding Box: Shows green bounding box around model
- Show Axes: Displays XYZ axes at model origin (100 units)
- Show Normals: Visualizes vertex normals as red lines (5 units)
- Show Edges: Clean edge visualization using EdgesGeometry (15° threshold)

All features follow the same pattern as existing skeleton/wireframe toggles:
- UI checkboxes in View section
- Event listeners for toggling visibility
- Helper creation/cleanup on model load
- Proper disposal and refresh on model attachment/detachment

Technical details:
- Imported VertexNormalsHelper from three/examples/jsm/helpers
- BoxHelper uses 0x00ff00 (green) color
- AxesHelper attached to model group (moves with model)
- Edges use white LineBasicMaterial with EdgesGeometry
- All helpers properly disposed when loading new models